### PR TITLE
Supertux Wayland fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SuperTux Nightly Builds
 -----------------------
 
-Experimental SuperTux nightly builds for Linux are available via [FlatPak](https://flatpak.org/):
+Experimental SuperTux nightly builds for Linux are available via [Flatpak](https://flatpak.org/):
 
     sudo flatpak remote-add --no-gpg-verify supertux "https://gitlab.com/supertux/flatpak/-/jobs/artifacts/master/raw/supertux-repo?job=build:flatpak"
     sudo flatpak install supertux org.supertuxproject.SuperTux

--- a/org.supertuxproject.SuperTux.json
+++ b/org.supertuxproject.SuperTux.json
@@ -10,7 +10,7 @@
     "finish-args":
     [
         "--socket=wayland",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--share=ipc",
         "--socket=pulseaudio",
         "--share=network",
@@ -25,6 +25,7 @@
         "*.a"
     ],
     "modules": [
+	"shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json",
         {
             "name": "fribidi",
             "sources":


### PR DESCRIPTION
This MR updates the shared-modules repo to include SDL2, and updates the README to use the SDL2 shared module bundled with libdecor.

Uses fallback-x11 for the display permissions.

Also fixed a typo in the README.

@Grumbel 