### PR TITLE
Update supertux-appdata.patch to remove "AND CC-BY-SA-2.0" from project_license value

### DIFF
--- a/supertux-appdata.patch
+++ b/supertux-appdata.patch
@@ -6,7 +6,7 @@ diff --git a/supertux2.appdata.xml b/supertux2.appdata.xml
    <id>org.supertuxproject.SuperTux</id>
    <metadata_license>CC0-1.0</metadata_license>
 -  <project_license>GPL-3.0+ AND CC-BY-SA-2.0</project_license>
-+  <project_license>GPL-3.0-or-later AND CC-BY-SA-2.0</project_license>
++  <project_license>GPL-3.0-or-later</project_license>
    <content_rating type="oars-1.1">
      <content_attribute id="violence-cartoon">mild</content_attribute>
      <content_attribute id="language-humor">mild</content_attribute>


### PR DESCRIPTION
Fixes #20 _yet again_. Hopefully for real this time.

Context: https://github.com/flathub/org.supertuxproject.SuperTux/issues/20#issuecomment-1826428232