### PR TITLE
Revert "Remove `env=SDL`"

### DIFF
--- a/org.supertuxproject.SuperTux.json
+++ b/org.supertuxproject.SuperTux.json
@@ -14,7 +14,8 @@
         "--share=ipc",
         "--socket=pulseaudio",
         "--share=network",
-        "--device=all"
+        "--device=all",
+        "--env=SDL_VIDEODRIVER=wayland,x11"
     ],
     "cleanup":
     [


### PR DESCRIPTION
See https://github.com/flathub/org.supertuxproject.SuperTux/issues/26

Need to investigate why this is necessary, but just work around it for now.

This reverts commit 412998b6a44df649986260a7b733f80607b4df1a.